### PR TITLE
Add JSON output support

### DIFF
--- a/changManderConcrete01/changManderConcrete01.cpp
+++ b/changManderConcrete01/changManderConcrete01.cpp
@@ -1662,17 +1662,33 @@ changManderConcrete01::recvSelf(int cTag, Channel &theChannel,
 void
 changManderConcrete01::Print(OPS_Stream &s, int flag)
 {
-	s<<"changManderConcrete01, tag: "<<this->getTag()<<endln;
-	s<<" Ec:      "<<Ec<<endln;
-	s<<" Fcn:     "<<Fc_n<<endln;
-	s<<" ecn:     "<<ec_n<<endln;
-	s<<" rn_pre:  "<<r_n_pre<<endln;
-	s<<" rn_post: "<<r_n_post<<endln;
-	s<<" xcrn:    "<<x_n_cr<<endln;
-	s<<" Fcp:     "<<Fc_p<<endln;
-	s<<" ecp:     "<<ec_p<<endln;
-	s<<" rp:      "<<r_p<<endln;
-	s<<" xcrp:    "<<x_p_cr<<endln;
+	if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+		s<<"changManderConcrete01, tag: "<<this->getTag()<<endln;
+		s<<" Ec:      "<<Ec<<endln;
+		s<<" Fcn:     "<<Fc_n<<endln;
+		s<<" ecn:     "<<ec_n<<endln;
+		s<<" rn_pre:  "<<r_n_pre<<endln;
+		s<<" rn_post: "<<r_n_post<<endln;
+		s<<" xcrn:    "<<x_n_cr<<endln;
+		s<<" Fcp:     "<<Fc_p<<endln;
+		s<<" ecp:     "<<ec_p<<endln;
+		s<<" rp:      "<<r_p<<endln;
+		s<<" xcrp:    "<<x_p_cr<<endln;
+	} else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+		s << "\t\t\t{";
+		s << "\"name\": \"" << this->getTag() << "\", ";
+		s << "\"type\": \"changManderConcrete01\", ";
+		s << "\"Ec\": " << Ec << ", ";
+		s << "\"Fcn\": " << Fc_n << ", ";
+		s << "\"ecn\": " << ec_n << ", ";
+		s << "\"rn_pre\": " << r_n_pre << ", ";
+		s << "\"rn_post\": " << r_n_post << ", ";
+		s << "\"xcrn\": " << x_n_cr << ", ";
+		s << "\"Fcp\": " << Fc_p << ", ";
+		s << "\"ecp\": " << ec_p << ", ";
+		s << "\"rp\": " << r_p << ", ";
+		s << "\"xcrp\": " << x_p_cr << "}";
+	}
 	return;
 }
 

--- a/mixedBeamColumn2d/mixedBeamColumn2d.cpp
+++ b/mixedBeamColumn2d/mixedBeamColumn2d.cpp
@@ -1184,6 +1184,21 @@ void mixedBeamColumn2d::Print(OPS_Stream &s, int flag) {
     for (int i = 0; i < numSections; i++)
       s << "\n"<<i<<" "<<xi[i]<<" "<<wt[i];
 
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": " << this->getTag() << ", ";
+    s << "\"type\": \"mixedBeamColumn2d\", ";
+    s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
+    s << "\"sections\": [";
+    for (int i = 0; i < numSections - 1; i++)
+      s << "\"" << sections[i]->getTag() << "\", ";
+    s << "\"" << sections[numSections - 1]->getTag() << "\"], ";
+    s << "\"integration\": ";
+    beamIntegr->Print(s, flag);
+    s << ", \"massperlength\": " << rho << ", ";
+    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\", ";
+    s << "\"geomLinear\": " << geomLinear << "}";
+
   } else {
     s << "\nElement: " << this->getTag() << " Type: mixedBeamColumn2d ";
     s << "\tConnected Nodes: " << connectedExternalNodes ;

--- a/mixedBeamColumn2d/mixedBeamColumn2d.cpp
+++ b/mixedBeamColumn2d/mixedBeamColumn2d.cpp
@@ -1196,8 +1196,10 @@ void mixedBeamColumn2d::Print(OPS_Stream &s, int flag) {
     s << "\"integration\": ";
     beamIntegr->Print(s, flag);
     s << ", \"massperlength\": " << rho << ", ";
-    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\", ";
-    s << "\"geomLinear\": " << geomLinear << "}";
+    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\"";
+    if (geomLinear)
+      s << ", \"geomLinear\": true";
+    s << "}";
 
   } else {
     s << "\nElement: " << this->getTag() << " Type: mixedBeamColumn2d ";

--- a/mixedBeamColumn2d/mixedBeamColumn2d.cpp
+++ b/mixedBeamColumn2d/mixedBeamColumn2d.cpp
@@ -1197,6 +1197,8 @@ void mixedBeamColumn2d::Print(OPS_Stream &s, int flag) {
     beamIntegr->Print(s, flag);
     s << ", \"massperlength\": " << rho << ", ";
     s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\"";
+    if (not doRayleigh)
+      s << ", \"doRayleigh\": false";
     if (geomLinear)
       s << ", \"geomLinear\": true";
     s << "}";

--- a/mixedBeamColumn3d/mixedBeamColumn3d.cpp
+++ b/mixedBeamColumn3d/mixedBeamColumn3d.cpp
@@ -1310,6 +1310,21 @@ void mixedBeamColumn3d::Print(OPS_Stream &s, int flag) {
     for (int i = 0; i < numSections; i++)
       s << "\n"<<i<<" "<<xi[i]<<" "<<wt[i];
 
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": " << this->getTag() << ", ";
+    s << "\"type\": \"mixedBeamColumn2d\", ";
+    s << "\"nodes\": [" << connectedExternalNodes(0) << ", " << connectedExternalNodes(1) << "], ";
+    s << "\"sections\": [";
+    for (int i = 0; i < numSections - 1; i++)
+      s << "\"" << sections[i]->getTag() << "\", ";
+    s << "\"" << sections[numSections - 1]->getTag() << "\"], ";
+    s << "\"integration\": ";
+    beamIntegr->Print(s, flag);
+    s << ", \"massperlength\": " << rho << ", ";
+    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\", ";
+    s << "\"geomLinear\": " << geomLinear << "}";
+
   } else {
     s << "\nElement: " << this->getTag() << " Type: mixedBeamColumn3d ";
     s << "\tConnected Nodes: " << connectedExternalNodes ;

--- a/mixedBeamColumn3d/mixedBeamColumn3d.cpp
+++ b/mixedBeamColumn3d/mixedBeamColumn3d.cpp
@@ -1323,6 +1323,8 @@ void mixedBeamColumn3d::Print(OPS_Stream &s, int flag) {
     beamIntegr->Print(s, flag);
     s << ", \"massperlength\": " << rho << ", ";
     s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\"";
+    if (not doRayleigh)
+      s << ", \"doRayleigh\": false";
     if (geomLinear)
       s << ", \"geomLinear\": true";
     s << "}";

--- a/mixedBeamColumn3d/mixedBeamColumn3d.cpp
+++ b/mixedBeamColumn3d/mixedBeamColumn3d.cpp
@@ -1322,8 +1322,10 @@ void mixedBeamColumn3d::Print(OPS_Stream &s, int flag) {
     s << "\"integration\": ";
     beamIntegr->Print(s, flag);
     s << ", \"massperlength\": " << rho << ", ";
-    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\", ";
-    s << "\"geomLinear\": " << geomLinear << "}";
+    s << "\"crdTransformation\": \"" << crdTransf->getTag() << "\"";
+    if (geomLinear)
+      s << ", \"geomLinear\": true";
+    s << "}";
 
   } else {
     s << "\nElement: " << this->getTag() << " Type: mixedBeamColumn3d ";

--- a/multiSurfaceKinematicHardening/multiSurfaceKinematicHardening.cpp
+++ b/multiSurfaceKinematicHardening/multiSurfaceKinematicHardening.cpp
@@ -558,13 +558,31 @@ int multiSurfaceKinematicHardening::recvSelf(int cTag, Channel &theChannel, FEM_
 }
 
 void multiSurfaceKinematicHardening::Print(OPS_Stream &s, int flag) {
-	s<<"multiSurfaceKinematicHardening, tag: "<<this->getTag()<<"\n";
-	s<<" E: "<<E<<"\n";
-	s<<" Initial Stress: "<<initStress<<"\n";
-	s<<" Number of Surfaces: "<<numSurfaces<<"\n";
-	for (int i=0; i<numSurfaces; i++) {
-    s<<"    #"<<i+1<<" Center = "<<startCenters[i]<<" Radius = "<<radii[i]<<" Hardening Modulus = "<<hardeningModulii[i]<<"\n";
+  if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+    s<<"multiSurfaceKinematicHardening, tag: "<<this->getTag()<<"\n";
+    s<<" E: "<<E<<"\n";
+    s<<" Initial Stress: "<<initStress<<"\n";
+    s<<" Number of Surfaces: "<<numSurfaces<<"\n";
+    for (int i=0; i<numSurfaces; i++) {
+      s<<"    #"<<i+1<<" Center = "<<startCenters[i]<<" Radius = "<<radii[i]<<" Hardening Modulus = "<<hardeningModulii[i]<<"\n";
+    }
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+    s << "\"type\": \"multiSurfaceKinematicHardening\", ";
+    s << "\"E\": " << E << ", ";
+    s << "\"initStress\": " << initStress << ", ";
+    s << "\"numSurfaces\": " << numSurfaces << ", ";
+    s << "\"surfaces\": [\n";
+    for (int i = 0; i < numSurfaces; i++) {
+      s << "\t\t\t\t{\"center\": " << startCenters[i] << ", \"radius\": " << radii[i] << ", \"hardeningModulus\": " << hardeningModulii[i] << "}";
+      if (i == numSurfaces - 1)
+        s << "\n";
+      else
+        s << ",\n";
+    }
+    s << "\t\t\t]}";
   }
-	return;
+  return;
 }
 

--- a/ratchet/ratchet.cpp
+++ b/ratchet/ratchet.cpp
@@ -259,9 +259,17 @@ int ratchet::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker
 }
 
 void ratchet::Print(OPS_Stream &s, int flag) {
-	s<<"ratchet, tag: "<<this->getTag()<<endln;
-	s<<" Forward Direction: "<<direction<<endln;
-	s<<" E: "<<E<<endln;
+  if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+    s<<"ratchet, tag: "<<this->getTag()<<endln;
+    s<<" Forward Direction: "<<direction<<endln;
+    s<<" E: "<<E<<endln;
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+		s << "\"type\": \"ratchet\", ";
+    s << "\"direction\": " << direction << ", ";
+    s << "\"E\": " << E << "}";
+  }
 	return;
 }
 

--- a/sakinoSunConcrete04/sakinoSunConcrete04.cpp
+++ b/sakinoSunConcrete04/sakinoSunConcrete04.cpp
@@ -529,14 +529,27 @@ int sakinoSunConcrete04::recvSelf (int commitTag, Channel& theChannel,
 
 void sakinoSunConcrete04::Print (OPS_Stream& s, int flag)
 {
-  s << "sakinoSunConcrete04, tag: " << this->getTag() << endln;
-  s << "  fpc: " << fpc << endln;
-  s << "  epsc0: " << epsc0 << endln;
-  s << "  fct: " << fct << endln;
-  s << "  w: " << w << endln;
-  s << "  Ec0:  " << Ec0 << endln;
-  s << "  etu:  " << etu << endln;
-  s << "  beta: " << beta << endln;
+  if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+    s << "sakinoSunConcrete04, tag: " << this->getTag() << endln;
+    s << "  fpc: " << fpc << endln;
+    s << "  epsc0: " << epsc0 << endln;
+    s << "  fct: " << fct << endln;
+    s << "  w: " << w << endln;
+    s << "  Ec0:  " << Ec0 << endln;
+    s << "  etu:  " << etu << endln;
+    s << "  beta: " << beta << endln;
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+    s << "\"type\": \"sakinoSunConcrete04\", ";
+    s << "\"fpc\": " << fpc << ", ";
+    s << "\"epsc0\": " << epsc0 << ", ";
+    s << "\"fct\": " << fct << ", ";
+    s << "\"w\": " << w << ", ";
+    s << "\"Ec0\": " << Ec0 << ", ";
+    s << "\"etu\": " << etu << ", ";
+    s << "\"beta\": " << beta << "}";
+  }
 }
 
 int

--- a/shenSteel01/shenSteel01.cpp
+++ b/shenSteel01/shenSteel01.cpp
@@ -1318,22 +1318,57 @@ int shenSteel01::recvSelf(int cTag, Channel &theChannel,
 }
 
 void shenSteel01::Print(OPS_Stream &s, int flag) {
-  s<<"shenSteel01, tag: "<<this->getTag()<<endln;
-  s<<" Es:      "<<Ee<<endln;
-  s<<" Fy:      "<<fy<<endln;
-  s<<" Fu:      "<<fu<<endln;
-  s<<" eu:      "<<eu<<endln;
-  s<<" kappaBar0: "<<Rbso<<" Ep0i: "<<Epoi<<" alpha: "<<alfa<<" a: "<<a<<" b: "<<bb<<" c: "<<c<<" omega: "<<w<<" zeta: "<<ksi<<" e: "<<e<<" f: "<<fE<< endln;
-  s<<" initStress: "<<initStress<<" alphaLat: "<<alphaLat<<" ep0: "<<ep0<<" Epst: "<<Est<< endln;
-  if (modelYieldPlateau == true)
-    s<<" modelYieldPlateau: true   M: "<<M<<" epst: "<<est<< endln;
-  if (modelLocalBuckling == true)
-    s<<" modelLocalBuckling: true  localBucklingStrain: "<<localBucklingStrain<<" Ksft: "<<Ksft<<" alphaFulb: "<<alphaFulb<<" refFulb: "<<refFulb<< endln;
-  if (modelDegradeEp == true)
-    s<<" modelDegradeEp: true      degradeEpRate: "<<degradeEpRate<<" degradeEpLimit: "<<degradeEpLimit<< endln;
-  if (modelDegradeKappa == true)
-    s<<" modelDegradeKappa: true   degradeKappaRate: "<<degradeKappaRate<<" degradeKappaLimit: "<<degradeKappaLimit<< endln;
-  if (modelDegradeFulb == true)
-    s<<" modelDegradeFulb: true    degradeFulbRate: "<<degradeFulbRate<<" degradeFulbLimit: "<<degradeFulbLimit<< endln;
+  if (flag == OPS_PRINT_PRINTMODEL_MATERIAL) {
+    s<<"shenSteel01, tag: "<<this->getTag()<<endln;
+    s<<" Es:      "<<Ee<<endln;
+    s<<" Fy:      "<<fy<<endln;
+    s<<" Fu:      "<<fu<<endln;
+    s<<" eu:      "<<eu<<endln;
+    s<<" kappaBar0: "<<Rbso<<" Ep0i: "<<Epoi<<" alpha: "<<alfa<<" a: "<<a<<" b: "<<bb<<" c: "<<c<<" omega: "<<w<<" zeta: "<<ksi<<" e: "<<e<<" f: "<<fE<< endln;
+    s<<" initStress: "<<initStress<<" alphaLat: "<<alphaLat<<" ep0: "<<ep0<<" Epst: "<<Est<< endln;
+    if (modelYieldPlateau == true)
+      s<<" modelYieldPlateau: true   M: "<<M<<" epst: "<<est<< endln;
+    if (modelLocalBuckling == true)
+      s<<" modelLocalBuckling: true  localBucklingStrain: "<<localBucklingStrain<<" Ksft: "<<Ksft<<" alphaFulb: "<<alphaFulb<<" refFulb: "<<refFulb<< endln;
+    if (modelDegradeEp == true)
+      s<<" modelDegradeEp: true      degradeEpRate: "<<degradeEpRate<<" degradeEpLimit: "<<degradeEpLimit<< endln;
+    if (modelDegradeKappa == true)
+      s<<" modelDegradeKappa: true   degradeKappaRate: "<<degradeKappaRate<<" degradeKappaLimit: "<<degradeKappaLimit<< endln;
+    if (modelDegradeFulb == true)
+      s<<" modelDegradeFulb: true    degradeFulbRate: "<<degradeFulbRate<<" degradeFulbLimit: "<<degradeFulbLimit<< endln;
+  } else if (flag == OPS_PRINT_PRINTMODEL_JSON) {
+    s << "\t\t\t{";
+    s << "\"name\": \"" << this->getTag() << "\", ";
+    s << "\"type\": \"shenSteel01\", ";
+    s << "\"Es\": " << Ee << ", ";
+    s << "\"Fy\": " << fy << ", ";
+    s << "\"Fu\": " << fu << ", ";
+    s << "\"eu\": " << eu << ", ";
+    s << "\"kappaBar0\": " << Rbso << ", ";
+    s << "\"Ep0i\": " << Epoi << ", ";
+    s << "\"alpha\": " << alfa << ", ";
+    s << "\"a\": " << a << ", ";
+    s << "\"b\": " << bb << ", ";
+    s << "\"c\": " << c << ", ";
+    s << "\"omega\": " << w << ", ";
+    s << "\"zeta\": " << ksi << ", ";
+    s << "\"e\": " << e << ", ";
+    s << "\"f\": " << fE << ", ";
+    s << "\"initStress\": " << initStress << ", ";
+    s << "\"alphaLat\": " << alphaLat << ", ";
+    s << "\"ep0\": " << ep0 << ", ";
+    s << "\"Epst\": " << Est;
+    if (modelYieldPlateau == true)
+      s << ", \"modelYieldPlateau\": true, \"M\": " << M << ", \"epst\": " << est;
+    if (modelLocalBuckling == true)
+      s << ", \"modelLocalBuckling\": true, \"localBucklingStrain\": " << localBucklingStrain << ", \"Ksft\": " << Ksft << ", \"alphaFulb\": " << alphaFulb << ", \"refFulb\": " << refFulb;
+    if (modelDegradeEp == true)
+      s << ", \"modelDegradeEp\": true, \"degradeEpRate\": " << degradeEpRate << ", \"degradeEpLimit\": " << degradeEpLimit;
+    if (modelDegradeKappa == true)
+      s << ", \"modelDegradeKappa\": true, \"degradeKappaRate\": " << degradeKappaRate << ", \"degradeKappaLimit\": " << degradeKappaLimit;
+    if (modelDegradeFulb == true)
+      s << ", \"modelDegradeFulb\": true, \"degradeFulbRate\": " << degradeFulbRate << ", \"degradeFulbLimit\": " << degradeFulbLimit;
+    s << "}";
+  }
   return;
 }


### PR DESCRIPTION
The `print` command in OpenSees supports printing the model as a JSON file:

``` tcl
print -JSON $file
```

However, each class is responsible for formatting its own output, which is handled by the `::Print` method. Annoyingly, you have to format the JSON by hand -- it's not done by a library or anything like that.

This PR adds JSON support for all the classes provided by this package.
